### PR TITLE
Update msteams_notification.js

### DIFF
--- a/src/lib/msteams_notification.js
+++ b/src/lib/msteams_notification.js
@@ -407,7 +407,7 @@ async function sendTeams(teamsWebhookObj, teamsConfig, templateContext, msgType)
         }
 
         if (msg !== null) {
-            const res = await teamsWebhookObj.send(JSON.stringify(msg));
+            const res = await teamsWebhookObj.send(msg);
             if (res !== undefined) {
                 globals.logger.debug(`TEAMSNOTIF: Result from calling TeamsApi.TeamsSend: ${res.statusText} (${res.status}): ${res.data}`);
             }


### PR DESCRIPTION
FIX the bug  Error: TEAMSNOTIF: Request failed with status code 500. , which is mainly cause by the JSON.stringify which modifies the content type to text instead of Application/json