### PR TITLE
Suppress experimental-feature-warning when telemetry is enabled

### DIFF
--- a/src/butler.js
+++ b/src/butler.js
@@ -2,6 +2,25 @@
 // Add dependencies
 import dgram from 'dgram';
 
+// Suppress experimental warnings
+// https://stackoverflow.com/questions/55778283/how-to-disable-warnings-when-node-is-launched-via-a-global-shell-script
+const originalEmit = process.emit;
+process.emit = function (name, data, ...args) {
+    // console.log(`Got a Node.js event: ${name}`);
+    // console.log(`Type of data: ${typeof data}`);
+    // if (typeof data === `object`) {
+    //     console.log(`Data: ${JSON.stringify(data)}`);
+    //     console.log(`Data name: ${data.name}`);
+    //     console.log(`Data message: ${data.message}`);
+    // }
+    // console.log(`Args: ${args}`);
+
+    if (name === `warning` && typeof data === `object` && data.name === `ExperimentalWarning` && data.message.includes(`Fetch API`)) {
+        return false;
+    }
+    return originalEmit.apply(process, arguments);
+};
+
 const start = async () => {
     // Load code from sub modules
     // Load globals dynamically/async to ensure singleton pattern works

--- a/src/test/env.js
+++ b/src/test/env.js
@@ -9,4 +9,3 @@ process.env.SUPPRESS_NO_CONFIG_WARNING = 'false';
 export const { NODE_CONFIG_DIR } = process.env;
 export const { SUPPRESS_NO_CONFIG_WARNING } = process.env;
 export const { NODE_ENV } = process.env;
-


### PR DESCRIPTION
Caused by telemetry code using features that were still experimental in Node 18 (which Butler currently uses)